### PR TITLE
added github actions to dependabot and pinned sha

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build-deploy-workflow.yml
+++ b/.github/workflows/build-deploy-workflow.yml
@@ -10,13 +10,16 @@ on:
 
 jobs:
  run:
-   uses: data-altinn-no/deploy-actions/.github/workflows/dan-deploy-flow.yml@e9a1d62778d9d2f4e8c2245027fb2750fd230e0a
-   with:
-     artifact_name: 'dan-plugin-sjofart' # Can be omitted, defaults to 'artifact'
-     function_project_path: 'src/Dan.Plugin.Sjofart'
-   secrets:
-     function_app_name: ${{ secrets.FUNCTIONAPP_NAME }}
-     publish_profile: ${{ secrets.AZURE_FUNCTION_PUBLISH_CREDS }}
-     azure_artifact_pat: ${{ secrets.AZURE_ARTIFACTS_PAT }}
-     azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-     resource_group_prod: ${{ secrets.RESOURCE_GROUP_PROD }}
+  permissions:
+    actions: read
+    contents: read
+  uses: data-altinn-no/deploy-actions/.github/workflows/dan-deploy-flow.yml@e9a1d62778d9d2f4e8c2245027fb2750fd230e0a
+  with:
+    artifact_name: 'dan-plugin-sjofart' # Can be omitted, defaults to 'artifact'
+    function_project_path: 'src/Dan.Plugin.Sjofart'
+  secrets:
+    function_app_name: ${{ secrets.FUNCTIONAPP_NAME }}
+    publish_profile: ${{ secrets.AZURE_FUNCTION_PUBLISH_CREDS }}
+    azure_artifact_pat: ${{ secrets.AZURE_ARTIFACTS_PAT }}
+    azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
+    resource_group_prod: ${{ secrets.RESOURCE_GROUP_PROD }}

--- a/.github/workflows/build-deploy-workflow.yml
+++ b/.github/workflows/build-deploy-workflow.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
  run:
-   uses: data-altinn-no/deploy-actions/.github/workflows/dan-deploy-flow.yml@main
+   uses: data-altinn-no/deploy-actions/.github/workflows/dan-deploy-flow.yml@e9a1d62778d9d2f4e8c2245027fb2750fd230e0a
    with:
      artifact_name: 'dan-plugin-sjofart' # Can be omitted, defaults to 'artifact'
      function_project_path: 'src/Dan.Plugin.Sjofart'


### PR DESCRIPTION
### Description
<!--- What and why -->
added github actions to dependabot and pinne sha version to reusable workflow

### Documentation
- [x] Doc updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated weekly updates for GitHub Actions workflows to the repository's dependency management.
  * Pinned the deployment workflow's action to a specific commit and added explicit read permissions for actions and contents to improve reliability and reproducibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->